### PR TITLE
[13.0][ADD] fleet_vehicle_history_date_end: Assign end date in vehicle's drivers history

### DIFF
--- a/fleet_vehicle_history_date_end/__init__.py
+++ b/fleet_vehicle_history_date_end/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2020-Present Druidoo - Manuel Marquez <manuel.marquez@druidoo.io>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import models

--- a/fleet_vehicle_history_date_end/__manifest__.py
+++ b/fleet_vehicle_history_date_end/__manifest__.py
@@ -1,0 +1,18 @@
+# Copyright 2020-Present Druidoo - Manuel Marquez <manuel.marquez@druidoo.io>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+{
+    "name": "Assign date end in vehicle history",
+    "summary": "Automatically assign date end in vehicle "
+    "history when a new driver is assigned.",
+    "category": "Human Resources/Fleet",
+    "author": "Druidoo, Odoo Community Association (OCA)",
+    "maintainers": ["mamcode", "ivantodorovich"],
+    "development_status": "Stable",
+    "website": "https://github.com/OCA/fleet",
+    "license": "AGPL-3",
+    "version": "13.0.1.0.0",
+    "depends": ["fleet"],
+    "data": [],
+    "installable": True,
+}

--- a/fleet_vehicle_history_date_end/models/__init__.py
+++ b/fleet_vehicle_history_date_end/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2020-Present Druidoo - Manuel Marquez <manuel.marquez@druidoo.io>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import fleet_vehicle_assignation_log

--- a/fleet_vehicle_history_date_end/models/fleet_vehicle_assignation_log.py
+++ b/fleet_vehicle_history_date_end/models/fleet_vehicle_assignation_log.py
@@ -1,0 +1,22 @@
+# Copyright 2020-Present Druidoo - Manuel Marquez <manuel.marquez@druidoo.io>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import api, models
+
+
+class FleetVehicleAssignationLog(models.Model):
+    _inherit = "fleet.vehicle.assignation.log"
+
+    @api.model
+    def create(self, vals):
+        res = super().create(vals)
+        history = self.search(
+            [
+                ("vehicle_id", "=", res.vehicle_id.id),
+                ("date_end", "=", False),
+                ("id", "!=", res.id),
+            ]
+        )
+        if history:
+            history.write({"date_end": res.date_start})
+        return res

--- a/fleet_vehicle_history_date_end/readme/CONTRIBUTORS.rst
+++ b/fleet_vehicle_history_date_end/readme/CONTRIBUTORS.rst
@@ -1,0 +1,4 @@
+* `Druidoo <https://www.druidoo.io>`_:
+
+  * Iván Todorovich <ivan.todorovich@druidoo.io>
+  * Manuel Marquez <manuel.marquez@druidoo.io>

--- a/fleet_vehicle_history_date_end/readme/DESCRIPTION.rst
+++ b/fleet_vehicle_history_date_end/readme/DESCRIPTION.rst
@@ -1,0 +1,1 @@
+Odoo only assign the start date on vehicle's drivers history when a new driver is assigned, this module also will assign automatically the end date in previous vehicle's driver histories when a new driver is assigned to the vehicle.

--- a/fleet_vehicle_history_date_end/tests/__init__.py
+++ b/fleet_vehicle_history_date_end/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2020-Present Druidoo - Manuel Marquez <manuel.marquez@druidoo.io>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from . import test_vehicle_history_date_end

--- a/fleet_vehicle_history_date_end/tests/test_vehicle_history_date_end.py
+++ b/fleet_vehicle_history_date_end/tests/test_vehicle_history_date_end.py
@@ -1,0 +1,46 @@
+# Copyright 2020-Present Druidoo - Manuel Marquez <manuel.marquez@druidoo.io>
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("-standard")
+class TestFleetVehicleDateEnd(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.vehicle = self.env["fleet.vehicle"].create(
+            {
+                "license_plate": "1-ACK-555",
+                "vin_sn": "883333",
+                "color": "Black",
+                "location": "Grand-Rosiere",
+                "doors": 5,
+                "driver_id": self.env.ref("base.user_demo_res_partner").id,
+                "odometer_unit": "kilometers",
+                "car_value": 20000,
+                "model_id": self.env.ref("fleet.model_astra").id,
+            }
+        )
+
+    def test_change_driver_history_date_end(self):
+        """Check correct assignation of date_end in history of previous driver."""
+        first_log = self.vehicle.log_drivers
+        self.assertFalse(first_log.date_end)
+        self.vehicle.write(
+            {"driver_id": self.env.ref("base.res_partner_address_25").id}
+        )
+        last_log = self.vehicle.log_drivers[0]
+        self.assertEqual(first_log.date_end, last_log.date_start)
+
+    def test_apply_future_driver(self):
+        """Check correct assignation of date_end in previos history log
+        when press button to apply future driver."""
+        first_log = self.vehicle.log_drivers
+        self.vehicle.write(
+            {"future_driver_id": self.env.ref("base.res_partner_address_17").id}
+        )
+        self.assertFalse(first_log.date_end)
+        self.vehicle.action_accept_driver_change()
+        last_log = self.vehicle.log_drivers[0]
+        self.assertEqual(first_log.date_end, last_log.date_start)

--- a/setup/fleet_vehicle_history_date_end/odoo/addons/fleet_vehicle_history_date_end
+++ b/setup/fleet_vehicle_history_date_end/odoo/addons/fleet_vehicle_history_date_end
@@ -1,0 +1,1 @@
+../../../../fleet_vehicle_history_date_end

--- a/setup/fleet_vehicle_history_date_end/setup.py
+++ b/setup/fleet_vehicle_history_date_end/setup.py
@@ -1,0 +1,6 @@
+import setuptools
+
+setuptools.setup(
+    setup_requires=['setuptools-odoo'],
+    odoo_addon=True,
+)


### PR DESCRIPTION
Odoo only assign the start date on vehicle's drivers history when a new driver is assigned, this module also will assign automatically the end date in previous vehicle's driver histories when a new driver is assigned to the vehicle.

![screenshot-localhost_8099-2020 05 20-21_29_26](https://user-images.githubusercontent.com/334317/82565389-58eb7d00-9b48-11ea-80c6-c45971466edc.png)