### PR TITLE
[FIX] fleet_vehicle_history_date_end: Remove test that checks the dat…

### DIFF
--- a/fleet_vehicle_history_date_end/tests/test_vehicle_history_date_end.py
+++ b/fleet_vehicle_history_date_end/tests/test_vehicle_history_date_end.py
@@ -1,11 +1,9 @@
 # Copyright 2020-Present Druidoo - Manuel Marquez <manuel.marquez@druidoo.io>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo.tests import tagged
 from odoo.tests.common import TransactionCase
 
 
-@tagged("-standard")
 class TestFleetVehicleDateEnd(TransactionCase):
     def setUp(self):
         super().setUp()
@@ -30,17 +28,5 @@ class TestFleetVehicleDateEnd(TransactionCase):
         self.vehicle.write(
             {"driver_id": self.env.ref("base.res_partner_address_25").id}
         )
-        last_log = self.vehicle.log_drivers[0]
-        self.assertEqual(first_log.date_end, last_log.date_start)
-
-    def test_apply_future_driver(self):
-        """Check correct assignation of date_end in previos history log
-        when press button to apply future driver."""
-        first_log = self.vehicle.log_drivers
-        self.vehicle.write(
-            {"future_driver_id": self.env.ref("base.res_partner_address_17").id}
-        )
-        self.assertFalse(first_log.date_end)
-        self.vehicle.action_accept_driver_change()
         last_log = self.vehicle.log_drivers[0]
         self.assertEqual(first_log.date_end, last_log.date_start)


### PR DESCRIPTION
…e end in application of future drivers, this feature (future drivers) does not exist in v12.