### PR TITLE
Avoid breaking event creation with other than service

### DIFF
--- a/fleet_vehicle_service_calendar/models/calendar_event.py
+++ b/fleet_vehicle_service_calendar/models/calendar_event.py
@@ -25,7 +25,8 @@ class CalendarEvent(models.Model):
         # sync res_model / res_id to service id
         # (aka creating meeting from service chatter)
         ctx = self.env.context
-        if "vehicle_service_id" not in defaults:
+        if "vehicle_service_id" not in defaults and \
+                defaults.get("res_model") == 'fleet.vehicle.log.services':
             defaults["vehicle_service_id"] = defaults.get("res_id", False) or ctx.get(
                 "default_res_id", False
             )


### PR DESCRIPTION
The code forces to add the vehicle_service_id in defaults even if the calendar meeting is not created from the fleet vehicle service stuff.
Check if res_model to link is really a fleet service otherwise leave as is.