### PR TITLE
[12.0][FIX] fleet_vehicle_inspection: changing the odometer requirement

### DIFF
--- a/fleet_vehicle_inspection/tests/test_fleet_vehicle_inspection.py
+++ b/fleet_vehicle_inspection/tests/test_fleet_vehicle_inspection.py
@@ -27,6 +27,7 @@ class TestFleetVehicleInspection(SavepointCase):
 
         cls.inspection = cls.inspection.create({
             'vehicle_id': cls.vehicle,
+            'odometer': 100,
             'inspection_line_ids': [
                 (0, 0,
                     {


### PR DESCRIPTION
While in draft mode, the odometer can be empty.

cc @ivantodorovich @mamcode @mymage 