### PR TITLE
[16.0][FIX] Avoid setting the value of the "vehicle service" field when creating …

### DIFF
--- a/fleet_vehicle_service_calendar/models/calendar_event.py
+++ b/fleet_vehicle_service_calendar/models/calendar_event.py
@@ -25,7 +25,10 @@ class CalendarEvent(models.Model):
         # sync res_model / res_id to service id
         # (aka creating meeting from service chatter)
         ctx = self.env.context
-        if "vehicle_service_id" not in defaults:
+        if (
+            "vehicle_service_id" not in defaults
+            and defaults.get("res_model") == "fleet.vehicle.log.services"
+        ):
             defaults["vehicle_service_id"] = defaults.get("res_id", False) or ctx.get(
                 "default_res_id", False
             )


### PR DESCRIPTION
…a meeting from models other than "fleet.vehicle.log.services"

reformatted

Fix calendar_event.py to check res model before setting "Vehicule service"

This will avoid setting the value of the "vehicle service" field when creating a meeting from models other than "fleet.vehicle.log.services"

Cherry-picked from #120 
Without this fix we can not create meeting activities to any model except fleet

@Jordi-Buitrago
