### PR TITLE
[15.0][FIX] fleet_vehicle_history_date_end

### DIFF
--- a/fleet_vehicle_history_date_end/models/fleet_vehicle_assignation_log.py
+++ b/fleet_vehicle_history_date_end/models/fleet_vehicle_assignation_log.py
@@ -2,6 +2,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, models
+from odoo.tools import date_utils
 
 
 class FleetVehicleAssignationLog(models.Model):
@@ -18,5 +19,5 @@ class FleetVehicleAssignationLog(models.Model):
             ]
         )
         if history:
-            history.write({"date_end": res.date_start})
+            history.write({"date_end": date_utils.subtract(res.date_start, days=1)})
         return res


### PR DESCRIPTION
I think it looks better when the end date of the current element in the log it the previous day from the start date of the next element.