### PR TITLE
[16.0][IMP] fleet_vehicle_inspection_template: add sequence to inspection template

### DIFF
--- a/fleet_vehicle_inspection_template/models/fleet_vehicle_inspection.py
+++ b/fleet_vehicle_inspection_template/models/fleet_vehicle_inspection.py
@@ -15,6 +15,7 @@ class FleetVehicleInspection(models.Model):
     def _compute_line_data_for_template_change(self, line):
         return {
             "inspection_item_id": line.inspection_template_item_id.id,
+            "sequence": line.sequence,
             "state": "draft",
         }
 
@@ -25,7 +26,9 @@ class FleetVehicleInspection(models.Model):
             self.note = self.inspection_template_id.note
 
             inspection_lines = [(5, 0, 0)]
-            for line in self.inspection_template_id.inspection_template_line_ids:
+            for line in self.inspection_template_id.inspection_template_line_ids.sorted(
+                "sequence"
+            ):
                 data = self._compute_line_data_for_template_change(line)
                 inspection_lines.append((0, 0, data))
 

--- a/fleet_vehicle_inspection_template/models/fleet_vehicle_inspection_template_line.py
+++ b/fleet_vehicle_inspection_template/models/fleet_vehicle_inspection_template_line.py
@@ -24,3 +24,5 @@ class FleetVehicleInspectionTemplateLine(models.Model):
         required=True,
         copy=True,
     )
+
+    sequence = fields.Integer(default=10)

--- a/fleet_vehicle_inspection_template/tests/test_fleet_vehicle_inspection_template.py
+++ b/fleet_vehicle_inspection_template/tests/test_fleet_vehicle_inspection_template.py
@@ -17,9 +17,9 @@ class TestFleetVehicleInspectionTemplate(TransactionCase):
 
         cls.item_02 = cls.inspection_item.create({"name": "Mirrors"})
 
-        cls.inspection_template = cls.inspection_template.create(
+        cls.inspection_template_01 = cls.inspection_template.create(
             {
-                "name": "TemplateTest",
+                "name": "TemplateTest_01",
                 "inspection_template_line_ids": [
                     (
                         0,
@@ -35,15 +35,69 @@ class TestFleetVehicleInspectionTemplate(TransactionCase):
             }
         )
 
+        cls.inspection_template_02 = cls.inspection_template.create(
+            {
+                "name": "TemplateTest_02",
+                "inspection_template_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "inspection_template_item_id": cls.item_01.id,
+                            "sequence": 11,  # Different sequence in the template line
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "inspection_template_item_id": cls.item_02.id,
+                            "sequence": 10,  # Different sequence in the template line
+                        },
+                    ),
+                ],
+            }
+        )
+
         cls.inspection = cls.inspection.create(
             {
                 "vehicle_id": cls.vehicle,
-                "inspection_template_id": cls.inspection_template.id,
+                "inspection_template_id": cls.inspection_template_01.id,
             }
         )
 
     def test_fleet_vehicle_inspection(self):
-
+        # --- Test with an inspection template ---
         self.inspection._onchange_inspection_template_id()
-        self.assertEqual(self.inspection.name, self.inspection_template.name)
+
+        self.assertEqual(self.inspection.name, self.inspection_template_01.name)
         self.assertTrue(self.inspection.inspection_line_ids)
+
+        # --- Change the template ID ---
+        self.inspection.inspection_template_id = self.inspection_template_02
+
+        # Trigger the onchange method again
+        self.inspection._onchange_inspection_template_id()
+
+        self.assertEqual(len(self.inspection.inspection_line_ids), 2)
+
+        # Check if the sequence is correctly copied from the template line
+        line_1 = self.inspection.inspection_line_ids.filtered(
+            lambda linei: linei.inspection_item_id == self.item_01
+        )
+        self.assertEqual(line_1.sequence, 11)
+
+        # --- Test without an inspection template ---
+        self.inspection.inspection_template_id = False  # Remove the template
+
+        # Trigger the onchange method again
+        self.inspection._onchange_inspection_template_id()
+
+        # Assert that the name and note are not changed
+        self.assertEqual(self.inspection.name, self.inspection_template_02.name)
+        # (remains the same as the previous template)
+        self.assertNotEqual(self.inspection.name, self.inspection_template_01.name)
+
+        # Assert that the inspection lines are NOT removed
+        self.assertTrue(self.inspection.inspection_line_ids)
+        self.assertEqual(len(self.inspection.inspection_line_ids), 2)

--- a/fleet_vehicle_inspection_template/views/fleet_vehicle_inspection_template.xml
+++ b/fleet_vehicle_inspection_template/views/fleet_vehicle_inspection_template.xml
@@ -27,6 +27,7 @@
                         >
                             <field name="inspection_template_line_ids">
                                 <tree editable="bottom">
+                                    <field name="sequence" widget="handle" />
                                     <field
                                         name="inspection_template_item_id"
                                         string="Inspection Template Line"


### PR DESCRIPTION
add seq widget to inspection templates allowing template itens reorder

Original template:
![image](https://github.com/user-attachments/assets/ca3079e9-843b-4d87-b4f9-1a6e909e38c9)
Inspection made with original template:
![image](https://github.com/user-attachments/assets/18fbcc7b-1145-4696-90bf-f97fa0694696)
Reordered template:
![image](https://github.com/user-attachments/assets/d4f96e78-5f8f-4f62-aca7-dff89f452856)
Inspection made with reordered template:
![image](https://github.com/user-attachments/assets/a344a9b4-e8d1-4420-8f7e-56c376dc2a35)
