### PR TITLE
[16.0][FIX] fleet_vehicle_ownership: fix position owner_id in form view

### DIFF
--- a/fleet_vehicle_ownership/views/fleet_vehicle_views.xml
+++ b/fleet_vehicle_ownership/views/fleet_vehicle_views.xml
@@ -5,7 +5,7 @@
         <field name="model">fleet.vehicle</field>
         <field name="inherit_id" ref="fleet.fleet_vehicle_view_form" />
         <field name="arch" type="xml">
-            <field name="company_id" position="after">
+            <field name="manager_id" position="after">
                 <field name="owner_id" />
             </field>
         </field>


### PR DESCRIPTION
In Odoo 16, in the fleet.fleet_vehicle_view_form form, there is an invisible company_id above the button_box.
This causes a view bug, as shown in the screenshot I included.

What if owner_id is placed after manager_id?

<img width="1309" height="350" alt="owner_id bug in fleet vehicle" src="https://github.com/user-attachments/assets/ae51b9b3-49c0-4c1e-ab9d-e3d29ad39aad" />
