### PR TITLE
[16.0][IMP] fleet_vehicle_stock: change required attrs in view

### DIFF
--- a/fleet_vehicle_stock/views/product_template.xml
+++ b/fleet_vehicle_stock/views/product_template.xml
@@ -28,10 +28,11 @@
         <field name="arch" type="xml">
             <page name="fleet" position="inside">
                 <field name="product_variant_count" invisible="1" />
+                <field name="create_fleet_vehicle" invisible="1" />
                 <group>
                     <field
                         name="fleet_vehicle_model_id"
-                        attrs="{'invisible': [('product_variant_count', '>', 1)], 'required': [('product_variant_count', '=', 1)]}"
+                        attrs="{'invisible': [('product_variant_count', '>', 1)], 'required': [('create_fleet_vehicle', '=', True)]}"
                     />
                 </group>
             </page>


### PR DESCRIPTION
Changes `fleet_vehicle_model_id` to be required only if `create_fleet_vehicle` is true. This fixes an issue where product creation was blocked for non-fleet products.

cc: @marcelsavegnago @CristianoMafraJunior @kaynnan 