### PR TITLE
[18.0][FIX] fleet_vehicle_ownership: fix position owner_id in form view

### DIFF
--- a/fleet_vehicle_ownership/views/fleet_vehicle_views.xml
+++ b/fleet_vehicle_ownership/views/fleet_vehicle_views.xml
@@ -5,7 +5,7 @@
         <field name="model">fleet.vehicle</field>
         <field name="inherit_id" ref="fleet.fleet_vehicle_view_form" />
         <field name="arch" type="xml">
-            <field name="company_id" position="after">
+            <field name="manager_id" position="after">
                 <field name="owner_id" />
             </field>
         </field>


### PR DESCRIPTION
This PR forward-ports the fix already merged for the 16.0 branch.

It addresses the same issue described in #189: in the fleet.fleet_vehicle_view_form view, an invisible company_id field placed above the button_box causes a layout issue. The solution is the same: move owner_id after manager_id.

Reference:
- OCA/fleet#189