### PR TITLE
[18.0][FIX] fleet_vehicle_inspection: fix dead search filters and unsafe multi-record button_confirm

### DIFF
--- a/fleet_vehicle_inspection/models/fleet_vehicle_inspection.py
+++ b/fleet_vehicle_inspection/models/fleet_vehicle_inspection.py
@@ -143,12 +143,13 @@ class FleetVehicleInspection(models.Model):
             raise ValidationError(
                 _("Only inspections in 'draft' or 'cancel' states can be confirmed")
             )
-        if self.amount:
-            if not self.service_type_id:
-                raise ValidationError(_("Must select service type"))
-            self.service_id = self.env["fleet.vehicle.log.services"].create(
-                self._prepare_fleet_vehicle_log_services_vals()
-            )
+        for rec in self:
+            if rec.amount:
+                if not rec.service_type_id:
+                    raise ValidationError(_("Must select service type"))
+                rec.service_id = self.env["fleet.vehicle.log.services"].create(
+                    rec._prepare_fleet_vehicle_log_services_vals()
+                )
         self.state = "confirmed"
         return True
 

--- a/fleet_vehicle_inspection/views/fleet_vehicle_inspection_views.xml
+++ b/fleet_vehicle_inspection/views/fleet_vehicle_inspection_views.xml
@@ -122,13 +122,13 @@
                 />
                 <filter
                     string="Inspection Completed"
-                    name="result"
-                    domain="[('state','=','completed')]"
+                    name="confirmed"
+                    domain="[('state','=','confirmed')]"
                 />
                 <filter
                     string="Inspection Canceled"
-                    name="result"
-                    domain="[('result','=','cancel')]"
+                    name="cancel"
+                    domain="[('state','=','cancel')]"
                 />
                 <separator />
                 <filter

--- a/fleet_vehicle_inspection_template/views/fleet_vehicle_inspection_template.xml
+++ b/fleet_vehicle_inspection_template/views/fleet_vehicle_inspection_template.xml
@@ -39,11 +39,7 @@
                         </page>
                     </notebook>
                 </sheet>
-                <div class="oe_chatter">
-                    <field name="message_follower_ids" widget="mail_followers" />
-                    <field name="activity_ids" widget="mail_activity" />
-                    <field name="message_ids" widget="mail_thread" />
-                </div>
+                <chatter />
             </form>
         </field>
     </record>


### PR DESCRIPTION
## Depend #233
## Summary
- Fix "Inspection Completed" and "Inspection Canceled" search filters, which compared `state`/`result` against values that never exist on those fields and therefore always returned an empty list.
- Make `button_confirm` safe to call on a recordset with more than one inspection, by iterating over `self` instead of reading `self.amount`/`self.service_type_id` directly (which raises `ValueError: Expected singleton`).

